### PR TITLE
Skip over bad segments when parsing set_cookie strings

### DIFF
--- a/lib/webrick/cookie.rb
+++ b/lib/webrick/cookie.rb
@@ -144,6 +144,7 @@ module WEBrick
       cookie_elem.each{|pair|
         pair.strip!
         key, value = pair.split(/=/, 2)
+        next if key.nil?
         if value
           value = HTTPUtils.dequote(value.strip)
         end

--- a/test/webrick/test_cookie.rb
+++ b/test/webrick/test_cookie.rb
@@ -108,6 +108,14 @@ class TestWEBrickCookie < Test::Unit::TestCase
     assert_equal(true, cookie.secure)
   end
 
+  def test_parse_set_cookie_bad_segment
+    data = 'Customer="WILE_E_COYOTE"; ;path="/acme"' # empty segement
+    cookie = WEBrick::Cookie.parse_set_cookie(data)
+    assert_equal("Customer", cookie.name)
+    assert_equal("WILE_E_COYOTE", cookie.value)
+    assert_equal("/acme", cookie.path)
+  end
+
   def test_parse_set_cookies
     data = %(Shipping="FedEx"; Version="1"; Path="/acme"; Secure)
     data << %(, CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; path=/; Secure)


### PR DESCRIPTION
A bad segment may be blank, in which case it should be skipped.