### PR TITLE
Add httponly field to WEBrick::Cookie

### DIFF
--- a/lib/webrick/cookie.rb
+++ b/lib/webrick/cookie.rb
@@ -58,6 +58,11 @@ module WEBrick
 
     attr_accessor :max_age
 
+    ##
+    # Is this an HTTPOnly cookie?
+
+    attr_accessor :httponly
+
     #attr_accessor :comment_url, :discard, :port
 
     ##
@@ -148,13 +153,14 @@ module WEBrick
           value = HTTPUtils.dequote(value.strip)
         end
         case key.downcase
-        when "domain"  then cookie.domain  = value
-        when "path"    then cookie.path    = value
-        when "expires" then cookie.expires = value
-        when "max-age" then cookie.max_age = Integer(value)
-        when "comment" then cookie.comment = value
-        when "version" then cookie.version = Integer(value)
-        when "secure"  then cookie.secure = true
+        when "domain"   then cookie.domain  = value
+        when "path"     then cookie.path    = value
+        when "expires"  then cookie.expires = value
+        when "max-age"  then cookie.max_age = Integer(value)
+        when "comment"  then cookie.comment = value
+        when "version"  then cookie.version = Integer(value)
+        when "secure"   then cookie.secure = true
+        when "httponly" then cookie.httponly = true
         end
       }
       return cookie

--- a/test/webrick/test_cookie.rb
+++ b/test/webrick/test_cookie.rb
@@ -99,13 +99,14 @@ class TestWEBrickCookie < Test::Unit::TestCase
     assert_equal(1, cookie.version)
     assert_equal("/acme", cookie.path)
 
-    data = %(Shipping="FedEx"; Version="1"; Path="/acme"; Secure)
+    data = %(Shipping="FedEx"; Version="1"; Path="/acme"; Secure; HTTPOnly)
     cookie = WEBrick::Cookie.parse_set_cookie(data)
     assert_equal("Shipping", cookie.name)
     assert_equal("FedEx", cookie.value)
     assert_equal(1, cookie.version)
     assert_equal("/acme", cookie.path)
     assert_equal(true, cookie.secure)
+    assert_equal(true, cookie.httponly)
   end
 
   def test_parse_set_cookies


### PR DESCRIPTION
Like Secure, just needs to check if the field exists, but it doesn't have a value in the set cookie segment.